### PR TITLE
Add support for converting 10 bit pixel formats

### DIFF
--- a/Bonsai.Spinnaker/SpinnakerCapture.cs
+++ b/Bonsai.Spinnaker/SpinnakerCapture.cs
@@ -99,7 +99,9 @@ namespace Bonsai.Spinnaker
             }
 
             PixelFormatEnums outputFormat;
-            if (pixelFormat == PixelFormatEnums.Mono12p ||
+            if (pixelFormat == PixelFormatEnums.Mono10p ||
+                pixelFormat == PixelFormatEnums.Mono10Packed ||
+                pixelFormat == PixelFormatEnums.Mono12p ||
                 pixelFormat == PixelFormatEnums.Mono12Packed)
             {
                 outputFormat = PixelFormatEnums.Mono16;


### PR DESCRIPTION
The new SDK version allows for explicit decoding from 10 bit pixel and packed pixel formats, so here we expand the range of supported grayscale pixel formats.

Fixes #8 