### PR TITLE
Capture configuration state before initialization

### DIFF
--- a/src/Bonsai.Spinnaker/SpinnakerCapture.cs
+++ b/src/Bonsai.Spinnaker/SpinnakerCapture.cs
@@ -190,6 +190,7 @@ namespace Bonsai.Spinnaker
         /// </returns>
         public IObservable<SpinnakerDataFrame> Generate<TSource>(IObservable<TSource> start)
         {
+            var captureInstance = (SpinnakerCapture)MemberwiseClone();
             return Observable.Create<SpinnakerDataFrame>((observer, cancellationToken) =>
             {
                 return Task.Factory.StartNew(async () =>
@@ -200,7 +201,7 @@ namespace Bonsai.Spinnaker
                         try
                         {
                             using var system = new ManagedSystem();
-                            var serialNumber = SerialNumber;
+                            var serialNumber = captureInstance.SerialNumber;
                             var cameraList = system.GetCameras();
                             if (!string.IsNullOrEmpty(serialNumber))
                             {
@@ -213,7 +214,7 @@ namespace Bonsai.Spinnaker
                             }
                             else
                             {
-                                var index = Index.GetValueOrDefault(0);
+                                var index = captureInstance.Index.GetValueOrDefault(0);
                                 if (index < 0 || index >= cameraList.Count)
                                 {
                                     var message = string.Format("No Spinnaker camera was found at index {0}.", index);
@@ -236,9 +237,9 @@ namespace Bonsai.Spinnaker
                     try
                     {
                         camera.Init();
-                        Configure(camera);
+                        captureInstance.Configure(camera);
 
-                        imageListener = new ImageEventListener(observer, ColorProcessing);
+                        imageListener = new ImageEventListener(observer, captureInstance.ColorProcessing);
                         camera.RegisterEventHandler(imageListener);
                         await start.ToTask(cancellationToken);
 


### PR DESCRIPTION
To allow parallel concurrent subscriptions we need to capture all operator configuration state before initialization. Here we leverage `MemberwiseClone` to do a shallow copy of the entire object state.

This will allow for derived implementations to keep overriding the `Configure` method and accessing instance state, since the operator will ensure it is captured. Other designs are possible but would introduce breaking changes.

Implementors should be aware not to use mutable reference classes as configuration state, as these will not be correctly copied.

Fixes #15 