### PR TITLE
Fix color processing on current Spinnaker SDK versions

### DIFF
--- a/src/Bonsai.Spinnaker/ColorProcessingAlgorithm.cs
+++ b/src/Bonsai.Spinnaker/ColorProcessingAlgorithm.cs
@@ -14,6 +14,56 @@
         /// Specifies that no debayering algorithm should be used and only the
         /// raw frame data is returned.
         /// </summary>
-        NoColorProcessing
+        NoColorProcessing,
+
+        /// <summary>
+        /// Specifies the fastest debayering algorithm, at the lowest quality.
+        /// </summary>
+        NearestNeighbor,
+
+        /// <summary>
+        /// Specifies nearest neighbor interpolation with averaged green pixels, for
+        /// higher quality than nearest neighbor at the expense of speed.
+        /// </summary>
+        NearestNeighborAverage,
+
+        /// <summary>
+        /// Specifies debayering by a weighted average of the surrounding pixels in a
+        /// 2x2 neighborhood.
+        /// </summary>
+        Bilinear,
+
+        /// <summary>
+        /// Specifies debayering by weighting surrounding pixels based on localized edge
+        /// orientation.
+        /// </summary>
+        EdgeSensing,
+
+        /// <summary>
+        /// Specifies a debayering algorithm well balanced between speed and quality.
+        /// </summary>
+        HQLinear,
+
+        /// <summary>
+        /// Specifies a multi-threaded debayering algorithm producing similar results to
+        /// edge sensing.
+        /// </summary>
+        Ipp,
+
+        /// <summary>
+        /// Specifies a high quality debayering algorithm that is more memory intensive
+        /// than the alternatives.
+        /// </summary>
+        DirectionalFilter,
+
+        /// <summary>
+        /// Specifies the slowest debayering algorithm, producing good quality results.
+        /// </summary>
+        Rigorous,
+
+        /// <summary>
+        /// Specifies debayering by a weighted pixel average from different directions.
+        /// </summary>
+        WeightedDirectionalFilter
     }
 }

--- a/src/Bonsai.Spinnaker/ImageEventListener.cs
+++ b/src/Bonsai.Spinnaker/ImageEventListener.cs
@@ -71,17 +71,20 @@ namespace Bonsai.Spinnaker
             }
 
             PixelFormatEnums outputFormat;
+            SpinnakerNET.ColorProcessingAlgorithm nativeColorProcessing;
             if (pixelFormat == PixelFormatEnums.Mono10p ||
                 pixelFormat == PixelFormatEnums.Mono10Packed ||
                 pixelFormat == PixelFormatEnums.Mono12p ||
                 pixelFormat == PixelFormatEnums.Mono12Packed)
             {
+                nativeColorProcessing = SpinnakerNET.ColorProcessingAlgorithm.NONE;
                 outputFormat = PixelFormatEnums.Mono16;
                 outputDepth = IplDepth.U16;
                 outputChannels = 1;
             }
             else if (pixelFormat >= PixelFormatEnums.BayerGR8 && pixelFormat <= PixelFormatEnums.BayerBG16)
             {
+                nativeColorProcessing = GetColorProcessingAlgorithm(colorProcessing);
                 outputFormat = PixelFormatEnums.BGR8;
                 outputDepth = IplDepth.U8;
                 outputChannels = 3;
@@ -96,9 +99,28 @@ namespace Bonsai.Spinnaker
                 unsafe
                 {
                     using var destination = new ManagedImage((uint)width, (uint)height, 0, 0, outputFormat, output.ImageData.ToPointer());
-                    image.ConvertToBitmapSource(outputFormat, destination, (SpinnakerNET.ColorProcessingAlgorithm)colorProcessing);
+                    image.ConvertToBitmapSource(outputFormat, destination, nativeColorProcessing);
                     return output;
                 }
+            };
+        }
+
+        static SpinnakerNET.ColorProcessingAlgorithm GetColorProcessingAlgorithm(ColorProcessingAlgorithm colorProcessing)
+        {
+            return colorProcessing switch
+            {
+                ColorProcessingAlgorithm.Default => SpinnakerNET.ColorProcessingAlgorithm.NEAREST_NEIGHBOR,
+                ColorProcessingAlgorithm.NoColorProcessing => SpinnakerNET.ColorProcessingAlgorithm.NONE,
+                ColorProcessingAlgorithm.NearestNeighbor => SpinnakerNET.ColorProcessingAlgorithm.NEAREST_NEIGHBOR,
+                ColorProcessingAlgorithm.NearestNeighborAverage => SpinnakerNET.ColorProcessingAlgorithm.NEAREST_NEIGHBOR_AVG,
+                ColorProcessingAlgorithm.Bilinear => SpinnakerNET.ColorProcessingAlgorithm.BILINEAR,
+                ColorProcessingAlgorithm.EdgeSensing => SpinnakerNET.ColorProcessingAlgorithm.EDGE_SENSING,
+                ColorProcessingAlgorithm.HQLinear => SpinnakerNET.ColorProcessingAlgorithm.HQ_LINEAR,
+                ColorProcessingAlgorithm.Ipp => SpinnakerNET.ColorProcessingAlgorithm.IPP,
+                ColorProcessingAlgorithm.DirectionalFilter => SpinnakerNET.ColorProcessingAlgorithm.DIRECTIONAL_FILTER,
+                ColorProcessingAlgorithm.Rigorous => SpinnakerNET.ColorProcessingAlgorithm.RIGOROUS,
+                ColorProcessingAlgorithm.WeightedDirectionalFilter => SpinnakerNET.ColorProcessingAlgorithm.WEIGHTED_DIRECTIONAL_FILTER,
+                _ => throw new ArgumentOutOfRangeException(nameof(colorProcessing))
             };
         }
     }


### PR DESCRIPTION
`SpinnakerCapture` casts its own `ColorProcessingAlgorithm` enum directly to the SpinnakerNET enum, which selects the wrong algorithm on current Spinnaker SDK versions where the two no longer match by ordinal, reported in #26. This change maps each value explicitly and exposes the remaining algorithms the SDK supports.

## What changes

`SpinnakerCapture` now maps each `ColorProcessing` value to the corresponding SpinnakerNET algorithm through an explicit switch instead of an ordinal cast. The public `ColorProcessingAlgorithm` enum keeps its `Default` and `NoColorProcessing` members, so existing workflows deserialize unchanged, and gains the full set the SDK offers: nearest neighbor, nearest neighbor average, bilinear, edge sensing, HQ linear, IPP, directional filter, rigorous, and weighted directional filter.

`Default` maps to nearest neighbor, matching the default SpinView uses for color cameras. The mono unpacking path requests no color processing, since a debayering algorithm only applies when converting a Bayer image to color.

## Impact

Color cameras debayer correctly again, and workflows can select any algorithm the SDK supports. `Default` now produces a fast nearest neighbor conversion rather than no conversion at all. Workflows that set `ColorProcessing` to `Default` or `NoColorProcessing` keep working unchanged, since the member names are preserved.

The explicit mapping targets the algorithm values of the supported SDK major, which the runtime resolver added in #25 already enforces, so a future major that renumbers the enum is rejected at load rather than silently mismapped.

Closes #26